### PR TITLE
Add feature to allow_partial_result as per need

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.0.1
+* Allow `allow_partial_result` in configuration and while calling any of `ParallelWorkforce.perform_all`;By default false but can make true if partial result needed
+
 ## 0.2.0
 
 * Add optional execution block to `ParallelWorkforce.perform_all` that is evaluated in calling thread after jobs enqueued,

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    parallel_workforce (1.0.0)
+    parallel_workforce (1.0.1)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ end
 * `job_key_expiration` - Time allowed for result key in Redis to remain before it expires. This should be larger than `job_timeout`. Default is `20` seconds.
 * `production_environment` - Removes serialization/deserialization when executing serially that helps locate problems with objects that fail to serialize. When `Rails` is loaded, uses `Rails.env.production?`, otherwise `true`.
 * `allow_nested_parallelization` - By default, executing `ParallelWorkforce.perform_all` within a ParallelWorkforce `Actor` will execute serially. This can be enabled to allow nesting worker invocations, but ensure that the worker pool is large enough to handle blocked workers waiting for a response. Too small of a pool will lead to timeouts as no workers will be available.
+* `allow_partial_result` - By default it will be false which mean partial result will be ignored and parallel workforce throws timeout error if any of actor's job failed but if partial result make sense to you can make it true.
 
 ## Development
 

--- a/lib/parallel_workforce.rb
+++ b/lib/parallel_workforce.rb
@@ -13,13 +13,14 @@ module ParallelWorkforce
     # Return results array with element from each action in the order of the job_args_array
     # rubocop:disable Metrics/ParameterLists
     def perform_all(actor_classes:, actor_args_array:,
-        serial_execution_indexes: nil, execute_serially: nil, job_class: nil, &execution_block)
+        serial_execution_indexes: nil, execute_serially: nil, job_class: nil,allow_partial_result: nil, &execution_block)
       ParallelWorkforce::Executor.new(
         actor_classes: actor_classes,
         actor_args_array: actor_args_array,
         execute_serially: execute_serially,
         serial_execution_indexes: serial_execution_indexes,
         job_class: job_class,
+        allow_partial_result: allow_partial_result,
         execution_block: execution_block,
       ).perform_all
     end

--- a/lib/parallel_workforce/configuration.rb
+++ b/lib/parallel_workforce/configuration.rb
@@ -11,6 +11,7 @@ module ParallelWorkforce
       :job_key_expiration,
       :production_environment,
       :allow_nested_parallelization,
+      :allow_partial_result,
     )
 
     def initialize
@@ -24,6 +25,7 @@ module ParallelWorkforce
       @job_key_expiration = 20
       @production_environment = defined?(Rails) ? Rails.env.production? : true
       @allow_nested_parallelization = false
+      @allow_partial_result = false
     end
   end
 end

--- a/lib/parallel_workforce/version.rb
+++ b/lib/parallel_workforce/version.rb
@@ -1,3 +1,3 @@
 module ParallelWorkforce
-  VERSION = "1.0.0".freeze
+  VERSION = "1.0.1".freeze
 end


### PR DESCRIPTION
Add feature to allow_partial_result as per need;
**allow_partial_result = false** by **default** and not break old code.
If someone wants to get partial result for any ParallelWorkforce.perform_all , they can pass **allow_partial_result: false** 