### PR TITLE
Rails i18n support

### DIFF
--- a/lib/parallel_workforce/job/active_job_rails.rb
+++ b/lib/parallel_workforce/job/active_job_rails.rb
@@ -11,12 +11,13 @@ module ParallelWorkforce
             server_revision: server_revision,
             serialized_actor_args: serialized_actor_args,
             time_zone_name: Time.zone.name,
+            locale: I18n.locale&.to_s,
           )
         end
       end
 
       def perform(args)
-        invoke_performer_with_time_zone_name(args)
+        invoke_performer_with_time_zone_name_and_locale(args)
       end
     end
   end

--- a/lib/parallel_workforce/job/sidekiq_rails.rb
+++ b/lib/parallel_workforce/job/sidekiq_rails.rb
@@ -11,12 +11,13 @@ module ParallelWorkforce
             server_revision: server_revision,
             serialized_actor_args: serialized_actor_args,
             time_zone_name: Time.zone.name,
+            locale: I18n.locale&.to_s,
           )
         end
       end
 
       def perform(args)
-        invoke_performer_with_time_zone_name(args)
+        invoke_performer_with_time_zone_name_and_locale(args)
       end
     end
   end

--- a/lib/parallel_workforce/job/util/job_helper.rb
+++ b/lib/parallel_workforce/job/util/job_helper.rb
@@ -47,11 +47,13 @@ module ParallelWorkforce
           ParallelWorkforce::Job::Util::Performer.new(**args).perform
         end
 
-        def invoke_performer_with_time_zone_name(args)
+        def invoke_performer_with_time_zone_name_and_locale(args)
           args.transform_keys!(&:to_sym)
 
           Time.use_zone(args.delete(:time_zone_name)) do
-            invoke_performer(args)
+            I18n.with_locale(args.delete(:locale)) do
+              invoke_performer(args)
+            end
           end
         end
       end

--- a/lib/parallel_workforce/version.rb
+++ b/lib/parallel_workforce/version.rb
@@ -1,3 +1,3 @@
 module ParallelWorkforce
-  VERSION = "3.0.0".freeze
+  VERSION = "4.0.0".freeze
 end

--- a/spec/parallel_workforce/job/active_job_rails_spec.rb
+++ b/spec/parallel_workforce/job/active_job_rails_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 module ParallelWorkforce::Job
   describe ActiveJobRails do
     time_zone_name = 'Pacific Time (US & Canada)'
+    locale = :en
 
     class ActiveJobRailsTestActor
       def initialize(value:)
@@ -14,10 +15,10 @@ module ParallelWorkforce::Job
       end
     end
 
-    let(:time_zone_name) { time_zone_name }
     let(:value) do
       {
         time_zone_name: Time.zone.name,
+        locale: I18n.locale,
         value: @value,
       }
     end
@@ -45,11 +46,11 @@ module ParallelWorkforce::Job
     end
 
     describe '.enqueue_actor' do
-      it_behaves_like 'enqueue_actor', :perform_later, time_zone_name
+      it_behaves_like 'enqueue_actor', :perform_later, time_zone_name, locale
     end
 
     describe '#perform' do
-      it_behaves_like 'perform', :perform_later, time_zone_name
+      it_behaves_like 'perform', :perform_later, time_zone_name, locale
     end
   end
 end

--- a/spec/parallel_workforce/job/sidekiq_rails_spec.rb
+++ b/spec/parallel_workforce/job/sidekiq_rails_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 module ParallelWorkforce::Job
   describe SidekiqRails do
     time_zone_name = 'Pacific Time (US & Canada)'
+    locale = :en
 
     class SidekiqRailsTestActor
       def initialize(value:)
@@ -14,10 +15,10 @@ module ParallelWorkforce::Job
       end
     end
 
-    let(:time_zone_name) { 'Pacific Time (US & Canada)' }
     let(:value) do
       {
         time_zone_name: Time.zone.name,
+        locale: I18n.locale,
         value: @value,
       }
     end
@@ -46,11 +47,11 @@ module ParallelWorkforce::Job
 
 
     describe '.enqueue_actor' do
-      it_behaves_like 'enqueue_actor', :perform_async, time_zone_name
+      it_behaves_like 'enqueue_actor', :perform_async, time_zone_name, locale
     end
 
     describe '#perform' do
-      it_behaves_like 'perform', :perform_async, time_zone_name
+      it_behaves_like 'perform', :perform_async, time_zone_name, locale
     end
   end
 end


### PR DESCRIPTION
Pass the current thread's `I18n.locale` as an argument to the worker and execute the worker in a `I18n.with_locale` block. This is analogous to how the Time.zone is handled.